### PR TITLE
Avoid apps getting stuck waiting on a response from broken WS

### DIFF
--- a/http/http.go
+++ b/http/http.go
@@ -141,6 +141,8 @@ func ListenWebSocketWithReconnectAlways[T any](newWebSocket func() (*websocket.C
 		if conn != nil {
 			_ = conn.Close()
 		}
+		// If this method returns, signal that no further values will be sent.
+		close(objects)
 	}()
 	for {
 		conn, err = newWebSocket()


### PR DESCRIPTION
When an error occurs (bad gateway or whatever), this function returns, logs an error, but the error response is usually ignored. To address this, and to keep in line with convention that the sender closes the channel, this change makes sure that on exiting we close the channel, so it's receivers will know that they shouldn't expect any other message (thus can restart the listener, for example).